### PR TITLE
Hostname Fix

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-i386-vagrant-disk1.box"
 
     config.vm.network :forwarded_port, guest: 8282, host: 8282
-    config.vm.network :forwarded_port, guest: 80, host: 80
+    config.vm.network :forwarded_port, guest: 80, host: 8000
     config.vm.network :forwarded_port, guest: 443, host: 443
 
     # uncomment for private network 

--- a/puppet/hiera/vagrant-1.yaml
+++ b/puppet/hiera/vagrant-1.yaml
@@ -55,4 +55,4 @@ uber_instances:
                 send_emails: 'False'
                 prereg_open: '2014-08-06'
 
-                hostname: 'vagrant-ubuntu-trusty-32'
+                hostname: 'localhost'


### PR DESCRIPTION
After some debugging with Dom on problems with local development, this should fix it for developers currently having trouble with accessing uber on their host machines.

Note: Skype still causes issues because it listens on both port 80 and port 443 by default (seriously, Skype?), so if you still have trouble, turn that setting off in Skype (under Advanced > Connections).
