### PR TITLE
"Fix" file mode for windows vagrant installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ puppet/fabric_settingsDONTUSE.ini
 .vagrant/
 puppet/modules/uber/
 sideboard/
+.idea/workspace.xml

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,6 +56,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 		# Make sure the facts directory exists
 		shell_cmd << "mkdir -p /etc/facter/facts.d/; "
 
+		# make this work for non-root users (they don't look in /etc/facter)
+		# more info here: https://projects.puppetlabs.com/issues/17875#change-82554
+		shell_cmd << "ln -s /etc/facter/ /home/vagrant/.facter; "
+
 		# add any facts we want (copy+paste this line)
 		shell_cmd << "echo 'is_vagrant=1' > /etc/facter/facts.d/is_vagrant.txt; "
 		

--- a/puppet/setup_vagrant_control_server.sh
+++ b/puppet/setup_vagrant_control_server.sh
@@ -4,3 +4,22 @@ sudo apt-get update -y
 sudo apt-get install -y fabric vim lynx git tofrodos
 
 fab -u root -H `hostname` bootstrap_vagrant_control_server
+
+# if we're running under windows, tell git to ignore file permissions on all git repos
+# (since the shared folders wrongly mark EVERYTHING as executable and
+# git tries to commit that change wrongly whenever you do a commit)
+#
+# read up on git's 'core.filemode' for more info
+#
+# this does mean that windows users can't mark things as executable in git repositories without
+# explicitly changing things, which is a drag.
+if [ "`facter is_vagrant_windows`" == '1' ];
+then
+    find /home/vagrant/uber -type d -name '.git' | while read -r FILE
+    do
+        git config --file "$FILE/config" core.filemode false
+    done
+fi
+
+echo "Deploy finished.  Please log in and out of bash in order for new bash aliases to work correctly,"
+echo "if not, certain commands may not work"

--- a/vagrant/vagrant.sh
+++ b/vagrant/vagrant.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# for the test DB to have words in it
+# dictionary stuff needed for the test DB code to have words to pull from
 sudo apt-get install -y wamerican language-pack-id
 sudo locale-gen en_US en_US.UTF-8 hu_HU hu_HU.UTF-8
 sudo dpkg-reconfigure locales
@@ -10,4 +10,5 @@ sudo dpkg-reconfigure locales
 # (we can't use symlinks with SMB shares)
 sudo patch /usr/lib/python3.4/venv/__init__.py < /home/vagrant/uber/vagrant/venv-symlink-fix.patch
 
+# setup our custom bash aliases to make development easy
 cp /home/vagrant/uber/vagrant/bash_aliases /home/vagrant/.bash_aliases


### PR DESCRIPTION
all files in windows+vagrant shared folders are marked as executable and git tries to commit this change. ARGH.

this makes a config change in each git repository in the shared folder, after initial deploy, that makes git ignore file perms.  we check to make sure the box is vagrant+windows before doing anything, so linux/mac vagrant instances are unaffected.

this slightly sucks because windows users, without some explicit options to git commit, won't be able to save permissions changes to scripts.
