### PR TITLE
vagrant: use 64bit ubuntu instead of 32bit

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.box = "Ubuntu 14.04"
-    config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-i386-vagrant-disk1.box"
+    config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
 
     config.vm.network :forwarded_port, guest: 8282, host: 8282
     config.vm.network :forwarded_port, guest: 80, host: 8000


### PR DESCRIPTION
needed for some package install stuff to come later

note: once this is merged, people will have to redploy if vagrant forces the box to be rebuilt (not sure if it will or not)

it should have always been on 64bit, not sure how I didn't notice this before.
