### PR TITLE
Update Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,10 +1,10 @@
 # -*- mode: ruby -*-
 
 VAGRANTFILE_API_VERSION = "2"
+Vagrant.require_version ">= 1.6.2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-    config.vm.box = "Ubuntu 14.04"
-    config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+    config.vm.box = "ubuntu/trusty64"
 
     config.vm.network :forwarded_port, guest: 8282, host: 8282
     config.vm.network :forwarded_port, guest: 80, host: 8000


### PR DESCRIPTION
use an actual 64bit box for installing.  not super-needed but this is the correct thing to do.  it doesn't change anything here but this is something we learned from the docker install that it's actually not running as 64bit without these exact lines.
