### PR TITLE
Setup magprime vagrant

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" project-jdk-name="Remote Python 3.4.0 Vagrant VM at C:/projects/ubersystem-deploy (/home/vagrant/uber/sideboard/env/bin/python3)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Remote Python interpreter" project-jdk-type="Python SDK" />
 </project>

--- a/.idea/msys.iml
+++ b/.idea/msys.iml
@@ -2,7 +2,7 @@
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$" />
-    <orderEntry type="jdk" jdkName="Remote Python 3.4.0 Vagrant VM at C:/projects/ubersystem-deploy (/home/vagrant/uber/sideboard/env/bin/python3)" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Remote Python interpreter" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Puppet modules" level="application" />
   </component>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -5,7 +5,7 @@
     <mapping directory="$PROJECT_DIR$/puppet/hiera/nodes" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/puppet/modules/uber" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/sideboard" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/sideboard/plugins/magclassic" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/sideboard/plugins/uber" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/sideboard/plugins/uber_analytics" vcs="Git" />
   </component>
 </project>

--- a/puppet/fabfile.py
+++ b/puppet/fabfile.py
@@ -20,6 +20,8 @@ class FabricConfig:
         self.git_secret_nodes_repo = self.read_config('repositories', 'git_secret_nodes_repo')
         self.git_secret_nodes_repo_branch = self.read_config('repositories', 'git_secret_nodes_repo_branch', None)
 
+        self.vagrant_extra_prefix = self.read_config('repositories', 'vagrant_extra_prefix', None)
+
 
     def read_config(self, section_name, option, default=None):
         try:
@@ -203,7 +205,12 @@ def copy_control_server_files():
 
     bootstrap_control_server()
 
+def setup_vagrant_prefix_facts():
+    if fabricconfig.vagrant_extra_prefix:
+        local("sudo bash -c 'echo vagrant_extra_prefix=" + fabricconfig.vagrant_extra_prefix + " > /etc/facter/facts.d/vagrant_extra_prefix.txt'")
+
 def bootstrap_vagrant_control_server():
+    setup_vagrant_prefix_facts()
     copy_control_server_files()
     puppet_apply_new_node(auto_update = False)
 

--- a/puppet/fabric_settings.example.ini
+++ b/puppet/fabric_settings.example.ini
@@ -49,3 +49,7 @@
 # 
 # git_secret_nodes_repo = "insert URL or PATH"
 # git_secret_nodes_repo_branch = "some_other_branch_different_from_master"
+
+
+# only used if doing a vagrant install, otherwise, ignored
+# vagrant_extra_prefix='prime'

--- a/puppet/hiera/hiera.yaml
+++ b/puppet/hiera/hiera.yaml
@@ -6,7 +6,7 @@
 :hierarchy:
         - "nodes/external/secret/%{::fqdn}"
         - "nodes/external/%{::fqdn}"
-        - "nodes/vagrant-%{::is_vagrant}"
+        - "nodes/vagrant-%{::vagrant_extra_prefix}%{::is_vagrant}"
         - "nodes/common"
         - "vagrant-%{::is_vagrant}"
         - "common"

--- a/puppet/hiera/vagrant-1.yaml
+++ b/puppet/hiera/vagrant-1.yaml
@@ -105,13 +105,14 @@ uber_instances:
                                 range_end: 7999
 
                 initial_attendee: 50    # badge price
-                badge_prices:
-                        single_day:
-                                - { 'Friday': 55 }
-                                - { 'Saturday': 55 }
-                                - { 'Sunday': 45 }
-                        attendee:
-                                - { '2015-08-01': 60 }
+
+                #badge_prices:
+                #        single_day:
+                #                - { 'Friday': 55 }
+                #                - { 'Saturday': 55 }
+                #                - { 'Sunday': 45 }
+                #        attendee:
+                #                - { '2015-08-01': 60 }
 
                 collect_exact_birthdate: 'True'
                 consent_form_url: ''


### PR DESCRIPTION
Makes it possible to use the master branch of ubersystem-deploy to run either magprime or magclassic settings.

Need to put these magfest-specific instructions somewhere about creating dev environments for both of these projects:
# For MagClassic

```
git clone http://github.com/magfest/ubersystem-deploy
```

then edit fabric-settings.ini and add the following line:

```
git_regular_nodes_repo = "https://github.com/magfest/production-config"
```

Then follow the rest of the instructions like normal from ubersystem-deploy

This will cause the deploy to use the config data in magfest/production-config's vagrant-1.yaml, which is setup to replicate MagClassic config settings as closely as possible.
# For MagPrime

same thing as above, except also add this line to fabric-settings.ini:

```
vagrant_extra_prefix='prime'
```

This will cause the deploy to use the config data in magfest/production-config's vagrant-prime1.yaml, which is setup to replicate MagPrime config settings as closely as possible.

---

What I recommend is that everyone have two copies of ubersystem-deploy using these methods, and switch between them as needed.  (you may not need to all that much if you're working on non-event-specific frontend stuff)

---

There are more PR's that should be merged at the same time as this one.  Will link them in a few minutes.
