### PR TITLE
fix FQDN not being set correctly on vagrant machines

### DIFF
--- a/puppet/hiera/common.yaml
+++ b/puppet/hiera/common.yaml
@@ -1,6 +1,5 @@
 ---
 # common settings, individual nodes can override this stuff
-uber::hostname:                 '%{::fqdn}'
 uber::path:                     '/usr/local/uber'
 uber::user:                     'rams'
 uber::group:                    'rams'


### PR DESCRIPTION
I now bestow upon @earl7399 the title of 'Lead QA builder' for identifying this one.

fix hostname not being correctly calculated on vagrant machines

Issue:
- this was breaking local vagrant builds
- facter doesn't set 'fqdn' fact at all if 'domain' fact isn't present
- on production nodes this was working fine because domain was fine
- on vagrant, domain wasn't set, so fqdn was "" which was causing nginx puppet (and other stuff) to crash out

To fix: puppet class uber::hostname falls back to 'hostname' if 'fqdn' isn't set.  Everything else now looks at this class for $uber::hostname.  Check out init.pp for the real fix.

I think this is actually fixed in exactly the same way in more recent versions of facter, we're using a pretty old version because it's what comes bundled on Ubuntu 14.04 .1 LTS

---

This would have been broken by the new puppet refactors because I reworked some of the hostname stuff, though, I swear I tested this with a from-scratch deploy and it worked. Weird.

Must be merged with https://github.com/magfest/ubersystem-puppet/pull/45
