### PR TITLE
require event_name to be given on vagrant setup

### DIFF
--- a/puppet/setup_vagrant_control_server.sh
+++ b/puppet/setup_vagrant_control_server.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 
-if [ $# -eq 1 ];
+if [ $# -ne 1 ];
 then
-	extra_args=":event_name=$1"
+	echo "usage: $0 event_name"
+	echo "example for an event named classic: $0 classic"
+	echo "if you don't know your event name, just use 'test'"
+	exit -1
 fi
+
+extra_args=":event_name=$1"
 
 sudo apt-get update -y
 sudo apt-get install -y fabric vim lynx git tofrodos


### PR DESCRIPTION
I think it's a bit less confusing to require the event_name to be passed in,
and then display a warning if they didn't do so with the suggested default action.
