### PR TITLE
listen on port 4444 for API calls

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,9 +6,15 @@ Vagrant.require_version ">= 1.6.2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.box = "ubuntu/trusty64"
 
-    config.vm.network :forwarded_port, guest: 8282, host: 8282
+    # normal nginx ports
     config.vm.network :forwarded_port, guest: 80, host: 8000
     config.vm.network :forwarded_port, guest: 4443, host: 4443
+
+    # normal nginx client cert API ports
+    config.vm.network :forwarded_port, guest: 4444, host: 4444
+
+    # expose cherrypy port directly for debugging purposes
+    config.vm.network :forwarded_port, guest: 8282, host: 8282
 
     # uncomment for private network 
     # (useful if doing SMB or NFS shares FROM the guest OS -to- host OS

--- a/puppet/hiera/common.yaml
+++ b/puppet/hiera/common.yaml
@@ -6,6 +6,7 @@ uber::group:                    'rams'
 
 uber::socket_port:              8282
 uber::ssl_port:                 443
+uber::ssl_api_port:             4444
 
 uber::plugins::sideboard_repo:    'https://github.com/magfest/sideboard'
 uber::plugins::sideboard_branch:  'master'


### PR DESCRIPTION
let vagrant listen on port 4444 for /jsonrpc calls

goes along with another PR
