### PR TITLE
Add alembic to new installs

### DIFF
--- a/vagrant/vagrant.sh
+++ b/vagrant/vagrant.sh
@@ -6,5 +6,8 @@ sudo apt-get install -y wamerican language-pack-id
 sudo locale-gen en_US en_US.UTF-8 hu_HU hu_HU.UTF-8
 sudo dpkg-reconfigure locales
 
+# DB Migrations
+pip install alembic
+
 # setup our custom bash aliases to make development easy
 cp /home/vagrant/uber/vagrant/bash_aliases /home/vagrant/.bash_aliases


### PR DESCRIPTION
Devs will need to use alembic to create upgrades, and production servers need it to run them.
