### PR TITLE
Centralized logging - turn on common config

### DIFF
--- a/puppet/hiera/common.yaml
+++ b/puppet/hiera/common.yaml
@@ -1,8 +1,12 @@
 ---
-# common settings, individual nodes can override this stuff
+# common settings for *ALL* installations, including non-magfest installs
+# individual servers can override this stuff
 uber::path:                     '/usr/local/uber'
 uber::user:                     'rams'
 uber::group:                    'rams'
+
+uber::daemon_name:              'uber_daemon'
+uber::app_logifle_name:         '/var/log/uber-app.log'
 
 uber::socket_port:              8282
 uber::ssl_port:                 443

--- a/puppet/hiera/common.yaml
+++ b/puppet/hiera/common.yaml
@@ -6,7 +6,7 @@ uber::user:                     'rams'
 uber::group:                    'rams'
 
 uber::daemon_name:              'uber_daemon'
-uber::app_logifle_name:         '/var/log/uber-app.log'
+uber::app_logfile_name:         '/var/log/uber-app.log'
 
 uber::socket_port:              8282
 uber::ssl_port:                 443

--- a/puppet/hiera/vagrant-1.yaml
+++ b/puppet/hiera/vagrant-1.yaml
@@ -15,8 +15,6 @@ uber::path:                     '/home/vagrant/uber/sideboard'
 uber::config::send_emails:      'True'
 uber::config::dev_box:          'True'
 
-uber::config::log_to_stderr:    'True'
-
 # sadly, ubersystem doesn't redirect correctly when the outside URL is 4443, and the backend url is forwarded to 443,
 # so we have to make 4443 be the port it listens to internally.
 uber::ssl_port:                 4443


### PR DESCRIPTION
Set daemon name and logfile output for sideboard installations
- needed to break this out so other sections of config could use it

merge same time as: https://github.com/magfest/ubersystem-puppet/pull/92
