### PR TITLE
enable caching for nginx, also add maintenance mode

### DIFF
--- a/puppet/hiera/common.yaml
+++ b/puppet/hiera/common.yaml
@@ -70,7 +70,12 @@ uber::config::numbered_badges:          'True'
 
 role_common::timezone:          'America/New_York'
 
-
+# nginx caching params
+nginx::proxy_cache_path: '/var/cache/nginx'
+nginx::proxy_cache_levels: '1:2'
+nginx::proxy_cache_keys_zone: 'one:8m'
+nginx::proxy_cache_max_size: '3000m'
+nginx::proxy_cache_inactive: '600m'
 
 # DO NOT CHECK IN == TRUE
 # if enabled, puppet will ignore the following things it normally handles:


### PR DESCRIPTION
- overhaul nginx config to enable caching of static content from ubersystem
- greatly reduces stress on the backend server and relieves it from having to serve up static content
- add maintenance mode, if you create /var/www/maintenance.html, all pages will redirect there

merge with https://github.com/magfest/ubersystem-puppet/pull/103
