### PR TITLE
ensure deny rules happen first

### DIFF
--- a/puppet/manifests/ssh.pp
+++ b/puppet/manifests/ssh.pp
@@ -19,13 +19,4 @@ class ssh {
     enable     => true,
     require    => File['/etc/ssh/sshd_config'],
   }
-
-  include ufw
-  
-  ufw::allow { 'allow-ssh-from-all':
-    port => 22,
-  }
-
-  # (the IP is blocked if it initiates 6 or more connections within 30 seconds):
-  ufw::limit { 22: }
 }


### PR DESCRIPTION
turns out ordering was important

these lines are moved into the uber puppet module now
