### PR TITLE
add maintenance deploy function

### DIFF
--- a/puppet/fabfile.py
+++ b/puppet/fabfile.py
@@ -250,31 +250,3 @@ def print_server_info():
     sudo("facter environment")
     print("fact: event_name is:")
     sudo("facter event_name")
-
-
-def maintenance_deploy(branch, deploy_dir, user='rams', restart_server=True):
-    """
-    Do a maintenance deploy against a still-running but obsolete ubersystem instance.
-    Typically after events are done, we don't update the code for that year anymore.
-
-    Sometimes though, we need to run queries and reports after the server is finished, so rather than use puppet,
-    we'll just do a manual git update and restart the server.
-
-    This assumes that branches or tags have been made for each release
-
-    :param branch:          Which branch should we set all git repos found at deploy_dir to.
-    :param deploy_dir:      Which directory the original installation was in.  All repos in this dir or subdirs will
-                            be updated to 'branch'
-    :param user:            Which user to run the git commands as
-    :param restart_server   If True, restart the server after the deploy is finished
-    """
-
-    assert branch != "master", "you probably don't want to set this branch to master, since this is for an old deploy"
-
-    dirs = run("find {} -name '.git'".format(deploy_dir)).replace('\r', '').split('\n')
-    for dir in [dir.replace('.git', '') for dir in dirs]:
-        with cd(dir):
-            sudo('git checkout %s' % (branch))
-
-    if restart_server:
-        restart_uber_service()

--- a/utils/create_maintenance_branches.sh
+++ b/utils/create_maintenance_branches.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# fail on any errors
+set -e
+
+if [ -z "$1" ]; then
+  echo "usage: $0 [event_name]"
+  echo "event_name will be used for naming branches. no spaces or special chars allowed. example: 'super2016'"
+  exit -1
+fi
+
+event_name="$1"
+branch_name="__release__$event_name"
+
+for i in `find -name '.git'`; do
+  pushd `dirname $i`
+  git fetch
+  git checkout -b $branch_name
+  git push origin $branch_name
+  git status
+  popd
+done


### PR DESCRIPTION
For doing updates to older non-maintained ubersystems

This simply creates a particular branch (like '__release_magfest2016') on every repo it finds in the target dir, and pushes it to github.  We could maybe use git tags for this, but, I expect we'll be updating these branches, so not sure if tags will work for this.

This allows us to update these release branches with cherry picked commits from later versions.  We'll use this primarily for things like accounting reports and table export functionality.

related to https://github.com/magfest/magbot/pull/10 (private repo, you need permission)
