### PR TITLE
Update fabfile when checking ssh key existence

### DIFF
--- a/puppet/fabfile.py
+++ b/puppet/fabfile.py
@@ -264,7 +264,7 @@ def bootstrap_vagrant_control_server(environment='development', event_name='test
 
 # generate an ssh key
 def generate_ssh_key_control_server_if_non_exists():
-    if os.path.exists("~/.ssh/id_rsa.pub"):
+    if os.path.exists(home_dir + "/.ssh/id_rsa.pub"):
         return
 
     local("ssh-keygen -f ~/.ssh/id_rsa -t rsa -C 'root@magfest-vagrant.com' -N '' ")


### PR DESCRIPTION
`os.path.exists` doesn't expand tilde, so use `os.path.expanduser("~")` (which is stored in a global as home_dir)

Found this when setting up a new dev system for the first time (things went wrong and running the script again tried to regen id_rsa, and things went more wrong), thought I should ease some setup pain.

I did a grep of ubersystem-deploy and I think this is the only instance of this issue.