### PR TITLE
Specify default vagrant provider

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,5 @@
 # -*- mode: ruby -*-
-
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
 VAGRANTFILE_API_VERSION = "2"
 Vagrant.require_version ">= 1.6.2"
 


### PR DESCRIPTION
Fedora recently changed their vagrant setup, which made deploys via this Vagrantfile stop working. This fixes that by explicitly setting the default provider to be correct.

Reference: https://developer.fedoraproject.org/tools/vagrant/vagrant-virtualbox.html