### PR TITLE
puppetize config option for number of staff shirts, swag shirts

### DIFF
--- a/puppet/hiera/common.yaml
+++ b/puppet/hiera/common.yaml
@@ -29,6 +29,7 @@ uber::config::year:                     33
 uber::config::initial_attendee: 50    # badge price
 uber::config::dealer_badge_price: 30
 uber::config::shirts_per_staffer: 0
+uber::config::staff_eligible_for_swag_shirt: True
 uber::config::max_dealers: 20
 uber::config::default_table_price: 350
 

--- a/puppet/hiera/common.yaml
+++ b/puppet/hiera/common.yaml
@@ -28,6 +28,7 @@ uber::config::year:                     33
 
 uber::config::initial_attendee: 50    # badge price
 uber::config::dealer_badge_price: 30
+uber::config::shirts_per_staffer: 0
 uber::config::max_dealers: 20
 uber::config::default_table_price: 350
 


### PR DESCRIPTION
set default to zero, most events don't use staff shirts. only supermag does otherwise