### PR TITLE
added missing default values

### DIFF
--- a/puppet/hiera/vagrant-1.yaml
+++ b/puppet/hiera/vagrant-1.yaml
@@ -18,3 +18,8 @@ uber::config::dev_box:          'True'
 # sadly, ubersystem doesn't redirect correctly when the outside URL is 4443, and the backend url is forwarded to 443,
 # so we have to make 4443 be the port it listens to internally.
 uber::ssl_port:                 4443
+
+uber::firewall_blacklisted_ips: []
+uber::config::prereg_faq_url:	'http://example.com/prereg-faq'
+uber::config::shirt_sizes:
+    no shirt: 0


### PR DESCRIPTION
I just upped a fresh Vagrant box for the first time in quite awhile, and since I'm on Linux I can't do the ``simple-rams-deploy``.  I noticed that there were three config options which are required which weren't present by default, so I added them to the ``vagrant-1.yaml`` hiera data file.