### PR TITLE
[wip] add year-specific event support for deploys

### DIFF
--- a/puppet/fabfile.py
+++ b/puppet/fabfile.py
@@ -275,7 +275,7 @@ def puppet_apply_new_node(auto_update = True, environment='development', event_n
 
 
 # do all setup tasks to get a node (a server which runs ubersystem) ready to do a 'puppet apply'
-def bootstrap_new_node(auto_update = True, environment='development', event_name='test'):
+def bootstrap_new_node(auto_update = True, environment='development', event_name='test', event_year=''):
     execute(register_remote_ssh_keys)
     execute(set_remote_hostname)
 
@@ -284,16 +284,17 @@ def bootstrap_new_node(auto_update = True, environment='development', event_name
 
     execute(install_initial_packages)
 
-    execute(setup_extra_node_specific_facter_facts, environment=environment, event_name=event_name)
+    execute(setup_extra_node_specific_facter_facts, environment=environment, event_name=event_name, event_year=event_year)
 
     if auto_update:
         execute(reboot_if_updates_needed)
 
 
-def setup_extra_node_specific_facter_facts(environment, event_name):
+def setup_extra_node_specific_facter_facts(environment, event_name, event_year):
     sudo("mkdir -p /etc/facter/facts.d/")
     sudo("bash -c 'echo event_name=" + event_name + " > /etc/facter/facts.d/event_name.txt'")
     sudo("bash -c 'echo environment=" + environment + " > /etc/facter/facts.d/environment.txt'")
+    sudo("bash -c 'echo event_year=" + event_year + " > /etc/facter/facts.d/event_year.txt'")
 
 
 def local_git_clone(repo_url, checkout_path, branch=None):

--- a/puppet/hiera/hiera.yaml
+++ b/puppet/hiera/hiera.yaml
@@ -6,6 +6,8 @@
 :hierarchy:
   # things in nodes/ are part of event-specific repositories, not included in this repo
   - "nodes/external/secret/%{::fqdn}"
+  - "nodes/external/secret/event-%{::event_name}-%{::event_year}-%{::environment}"
+  - "nodes/external/secret/event-%{::event_name}-%{::event_year}"
   - "nodes/external/secret/event-%{::event_name}-%{::environment}"
   - "nodes/external/secret/event-%{::event_name}"
   - "nodes/external/secret/%{::environment}"
@@ -13,6 +15,8 @@
   - "nodes/external/%{::fqdn}"
   - "nodes/vagrant-%{::event_name}-%{::is_vagrant}"
   - "nodes/vagrant-%{::is_vagrant}"
+  - "nodes/event-%{::event_name}-%{::event_year}-%{::environment}"
+  - "nodes/event-%{::event_name}-%{::event_year}"
   - "nodes/event-%{::event_name}-%{::environment}"
   - "nodes/event-%{::event_name}"
   - "nodes/%{::environment}"

--- a/puppet/setup_vagrant_control_server.sh
+++ b/puppet/setup_vagrant_control_server.sh
@@ -2,7 +2,7 @@
 
 if [ $# -eq 1 ];
 then
-	extra_args=":event_name=$1"
+	extra_args=":event_name=$1,event_year=$2"
 fi
 
 sudo apt-get update -y
@@ -17,7 +17,7 @@ fab -u root -H `hostname` bootstrap_vagrant_control_server$extra_args
 # read up on git's 'core.filemode' for more info
 #
 # this does mean that windows users can't mark things as executable in git repositories without
-# explicitly changing things, which is a drag.
+# explicitly changing things, which sucks.
 if [ "`facter is_vagrant_windows`" == '1' ];
 then
     find /home/vagrant/uber -type d -name '.git' | while read -r FILE


### PR DESCRIPTION
Add year-specific support to hiera.yaml and associated deploy files.

The key here is this will let us do things like specify YAML config settings on a per-year basis, so we can set things in files like:
- event-labs-2018.yaml       [2018-specific settings/dates + current credentials + send_emails true/etc]
- event-labs-2017.yaml       [2017-specific settings/dates + disable AWS,Twilio,Stripe credentials, send_emails false/etc]
- event-labs.yaml       [all common labs server settings like themes]

must merge with https://github.com/magfest/simple-rams-deploy/pull/35

the other cool thing about this is it can replace the concept of an 'archive deploy' by specifying specific release labels/branches if we wanted to fix the older servers at a particular point in time, and only explicitly backport features.

before merging
- [ ] update magbot to pass in / enforce a valid event year for the 'init_server' task
- [x] test all of this on staging servers and with vagrant (I didn't test it at all yet)
- [x] on any existing servers, manually set the contents of /etc/facter/facts.d/event_year.txt to the correct year [2017 or 2018]
- [x] create appropriate year-specific config .yaml files both in production-config and on mcp's secrets folder that split out old vs new settings.
- [ ] probably create 2 staging servers for 2017 vs 2018 labs instances to test it all out